### PR TITLE
adding nr, rain particle concentration, to products in Shipway and Hill

### DIFF
--- a/PySDM_examples/Shipway_and_Hill_2012/simulation.py
+++ b/PySDM_examples/Shipway_and_Hill_2012/simulation.py
@@ -119,6 +119,9 @@ class Simulation:
                 name="nc", radius_range=settings.cloud_water_radius_range
             ),
             PySDM_products.ParticleConcentration(
+                name="nr", radius_range=settings.rain_water_radius_range
+            ),
+            PySDM_products.ParticleConcentration(
                 name="na", radius_range=(0, settings.cloud_water_radius_range[0])
             ),
             PySDM_products.MeanRadius(),


### PR DESCRIPTION
It is useful to save rain particle concentration as a scalar product. In this PR I added the product in Shipway and Hill example.